### PR TITLE
Subject removed from templates - updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-Add placeholder setting for fields
+## 0.7 
+-  remove the model instance's subject from template.

--- a/contact/templates/contact/email/message.html
+++ b/contact/templates/contact/email/message.html
@@ -5,7 +5,6 @@
     {% block body %}
         <p>Name: {{ obj.name }}.</p>
         <p>Email: {{ obj.email }}</p>
-        <p>Subject: {{ obj.subject }}</p>
         <p>Message: {{ obj.message }}</p>
     {% endblock body %}
 </body>

--- a/contact/templates/contact/email/message.txt
+++ b/contact/templates/contact/email/message.txt
@@ -1,8 +1,6 @@
 Name: {{ obj.name }}
 Email: {{ obj.email }}
 
-Subject:
-{{ obj.subject}}
 Message:
 {{ obj.message }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-contact"
-version = "0.6"
+version = "0.7"
 description = "Adds a generic contact app for use with Giant projects"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"


### PR DESCRIPTION
# Forecast Ticket Link(s)
https://app.forecast.it/project/P-287/task-board/T25268

I appreciate this is barely used anymore but this change is needed for UKHIH. Seems bizzare writing the subject in the email body.